### PR TITLE
Potential fix for code scanning alert no. 79: Type confusion through parameter tampering

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -18,7 +18,12 @@ class ErrorWithParent extends Error {
 // vuln-code-snippet start unionSqlInjectionChallenge dbSchemaChallenge
 export function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
-    let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    let criteria: string
+    if (typeof req.query.q === 'string') {
+      criteria = req.query.q
+    } else {
+      criteria = ''
+    }
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
Potential fix for [https://github.com/diegorfreitas-coder/juice-shop/security/code-scanning/79](https://github.com/diegorfreitas-coder/juice-shop/security/code-scanning/79)

To fix the issue, we need to ensure that `req.query.q` is explicitly validated to be a string before it is used. If it is not a string, we should handle it appropriately (e.g., defaulting to an empty string or rejecting the request). This can be achieved by adding a type check for `req.query.q` and ensuring that `criteria` is always a string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
